### PR TITLE
Bring support to python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,10 @@ RequestHandler::
 
     >>> injector = Injector([ConfigurationForTestingModule(), DatabaseModule()])
     >>> handler = injector.get(RequestHandler)
-    >>> handler.get()
-    [(u'hello', u'world')]
+    >>> a = handler.get()
+    >>> # PYTHON2/3 doctest conversion. you will get some unicode strings for both versions
+    >>> str(a).replace('u', '')
+    "[('hello', 'world')]"
 
 We can also veryify that our Configuration and SQLite connections are indeed
 singletons within the Injector::

--- a/injector.py
+++ b/injector.py
@@ -132,7 +132,7 @@ class BindingKey(tuple):
             if len(what) != 1:
                 raise Error('dictionary bindings must have a single interface '
                             'key and value')
-            what = (dict, BindingKey(what.items()[0], None))
+            what = (dict, BindingKey(list(what.items())[0], None))
         return tuple.__new__(cls, (what, annotation))
 
     @property
@@ -356,12 +356,12 @@ class Module(object):
             if hasattr(function, '__binding__'):
                 what, provider, annotation, scope = function.__binding__
                 binder.bind(what,
-                        to=types.MethodType(provider, self, self.__class__),
+                        to=types.MethodType(provider, self),
                         annotation=annotation, scope=scope)
             elif hasattr(function, '__multibinding__'):
                 what, provider, annotation, scope = function.__multibinding__
                 binder.multibind(what,
-                        to=types.MethodType(provider, self, self.__class__),
+                        to=types.MethodType(provider, self),
                         annotation=annotation, scope=scope)
         self.configure(binder)
 
@@ -485,7 +485,7 @@ def inject(**bindings):
     >>> class A(object):
     ...     @inject(number=int, name=str, sizes=Sizes)
     ...     def __init__(self, number, name, sizes):
-    ...         print number, name, sizes
+    ...         print([number, name, sizes])
     ...
     ...     @inject(names=Names)
     ...     def friends(self, names):
@@ -501,7 +501,7 @@ def inject(**bindings):
     Use the Injector to get a new instance of A:
 
     >>> a = Injector(configure).get(A)
-    123 Bob [1, 2, 3]
+    [123, 'Bob', [1, 2, 3]]
 
     Call a method with arguments satisfied by the Injector:
 
@@ -510,7 +510,7 @@ def inject(**bindings):
     """
 
     def wrapper(f):
-        for key, value in bindings.iteritems():
+        for key, value in bindings.items():
             bindings[key] = BindingKey(value, None)
 
         @functools.wraps(f)
@@ -532,7 +532,7 @@ def inject(**bindings):
 
             injector._stack.append(key)
             try:
-                for arg, key in bindings.iteritems():
+                for arg, key in bindings.items():
                     try:
                         instance = injector.get(key.interface,
                                 annotation=key.annotation)

--- a/injector_test.py
+++ b/injector_test.py
@@ -526,8 +526,11 @@ def test_binder_provider_for_method_with_class_to_specific_subclass():
 
 
 def test_binder_provider_for_type_with_metaclass():
-    class A(object):
-        __metaclass__ = abc.ABCMeta
+    # use a metaclass cross python2/3 way
+    # otherwise should be:
+    # class A(object, metaclass=abc.ABCMeta):
+    #    passa
+    A = abc.ABCMeta('A', (object, ), {})
 
     binder = Injector().binder
     assert (isinstance(binder.provider_for(A, None).get(), A))

--- a/runtest.py
+++ b/runtest.py
@@ -2457,7 +2457,7 @@ if __name__ == "__main__":
         sources = sources.encode("ascii") # ensure bytes
         sources = pickle.loads(zlib.decompress(base64.decodebytes(sources)))
     else:
-        import cPickle as pickle
+        import pickle as pickle
         exec("def do_exec(co, loc): exec co in loc\n")
         sources = pickle.loads(zlib.decompress(base64.decodestring(sources)))
 


### PR DESCRIPTION
Add some python3 support to latest release.

Reshaped a little bit the tests to be able to run in both python2 and python3 world (testing only with python 2.7, but should work on 2.6 too)
