### PR TITLE
Add CallError exception class to better show why injection/instantiation fails

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -51,9 +51,9 @@ class CallError(Error):
         instance, method, args, kwargs, original_error = self.args
         if hasattr(method, 'im_class'):
             instance = method.__self__
-            method_name = method.im_func.func_name
+            method_name = method.__func__.__name__
         else:
-            method_name = method.func_name
+            method_name = method.__name__
 
         full_method = '.'.join((repr(instance) if instance else '', method_name)).strip('.')
 
@@ -480,7 +480,7 @@ class Injector(object):
         try:
             instance.__init__()
         except TypeError as e:
-            raise CallError(instance, instance.__init__.im_func, (), {}, e)
+            raise CallError(instance, instance.__init__.__func__, (), {}, e)
         return instance
 
     def install_into(self, instance):

--- a/injector_test.py
+++ b/injector_test.py
@@ -607,7 +607,14 @@ def test_injecting_undecorated_class_with_missing_dependencies_raises_the_right_
     try:
         b = injector.get(B)
     except CallError as ce:
-        assert (ce.args[1] == A.__init__.im_func)
+        function = A.__init__
+
+        # Python 3 compatibility
+        try:
+            function = function.__func__
+        except AttributeError:
+            pass
+        assert (ce.args[1] == function)
 
 def test_call_to_method_containing_noninjectable_and_unsatisfied_dependencies_raises_the_right_error():
     class A(object):
@@ -624,7 +631,14 @@ def test_call_to_method_containing_noninjectable_and_unsatisfied_dependencies_ra
 
         # We cannot really check for function identity here... Error is raised after calling
         # original function but from outside we have access to function already decorated
-        assert (ce.args[1].func_name == A.fun.im_func.func_name)
+        function = A.fun
+
+        # Python 3 compatibility
+        try:
+            function = function.__func__
+        except AttributeError:
+            pass
+        assert (ce.args[1].__name__ == function.__name__)
 
         assert (ce.args[2] == ())
         assert (ce.args[3] == {'something': str()})


### PR DESCRIPTION
When injector fails to provide dependency or instantiate a class it's hard to understand from the stack trace what went wrong, what was injected and what was not. This patch makes stack traces a bit more readable.

It's not an ideal, maybe the exception should be slightly less verbose (to not include object/function identifier for example).

Example 1:

```
from injector import inject, Injector

class A(object):
    def __init__(self, parameter):
        self.parameter = parameter

class B(object):
    @inject(a = A)
    def __init__(self, a):
        pass

class C(object):
    @inject(a = A)
    def __init__(self, a):
        pass

    @inject(b = B)
    def fun(self, b, x):
        pass

def main():
    injector = Injector()
    c = injector.get(C)
    c.fun()

if __name__ == '__main__':
    main()
```

Output before patch:

```
Traceback (most recent call last):
  File "asd.py", line 30, in <module>
    main()
  File "asd.py", line 26, in main
    c = injector.get(C)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 462, in get
    return scope_instance.get(key, binding.provider).get()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 86, in get
    return self.injector.create_object(self._cls)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 472, in create_object
    instance.__init__()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 629, in inject
    owner_key=self_.__class__,
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 507, in args_to_inject
    annotation=key.annotation)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 462, in get
    return scope_instance.get(key, binding.provider).get()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 86, in get
    return self.injector.create_object(self._cls)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 472, in create_object
    instance.__init__()
TypeError: __init__() takes exactly 2 arguments (1 given)
```

Output after patch:

```
Traceback (most recent call last):
  File "ex1.py", line 30, in <module>
    main()
  File "ex1.py", line 26, in main
    c = injector.get(C)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 462, in get
    return scope_instance.get(key, binding.provider).get()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 86, in get
    return self.injector.create_object(self._cls)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 473, in create_object
    instance.__init__()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 635, in inject
    owner_key=self_.__class__,
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 510, in args_to_inject
    annotation=key.annotation)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 462, in get
    return scope_instance.get(key, binding.provider).get()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 86, in get
    return self.injector.create_object(self._cls)
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 475, in create_object
    raise CallError(None, instance.__init__, [], {}, e)
injector.CallError: Call to <bound method A.__init__ of <__main__.A object at 0x100a490>>() failed: __init__() takes exactly 2 arguments (1 given)
```

Example 2:

```
from injector import inject, Injector

class A(object):
    @inject(parameter = dict)
    def __init__(self, parameter):
        self.parameter = parameter

class B(object):
    @inject(a = A)
    def __init__(self, a):
        pass

class C(object):
    @inject(a = A)
    def __init__(self, a):
        pass

    @inject(b = B)
    def fun(self, b, x):
        pass

def main():
    injector = Injector()
    c = injector.get(C)
    c.fun()

if __name__ == '__main__':
    main()
```

Output before patch:

```
Traceback (most recent call last):
  File "asd.py", line 31, in <module>
    main()
  File "asd.py", line 28, in main
    c.fun()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 632, in inject
    return f(self_, *args, **dependencies)
TypeError: fun() takes exactly 3 arguments (2 given)
```

Output after patch:

```
Traceback (most recent call last):
  File "ex2.py", line 31, in <module>
    main()
  File "ex2.py", line 28, in main
    c.fun()
  File "/home/a/ve/lib64/python2.7/site-packages/injector.py", line 641, in inject
    raise CallError(self_, f, args, dependencies, e)
injector.CallError: Call to <__main__.C object at 0x8d6390>.<function fun at 0x8d7140>(b=<__main__.B object at 0x8d6490>) failed: fun() takes exactly 3 arguments (2 given)
```
