### PR TITLE
Prevent Key-created type instantiation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,8 @@ Assisted injection
 Sometimes there are classes that have injectable and non-injectable parameters in their
 constructors. Let's have for example::
 
-    >>> Database = Key('Database')
+    >>> class Database(object): pass
+
     >>> class User(object):
     ...     def __init__(self, name):
     ...         self.name = name

--- a/injector.py
+++ b/injector.py
@@ -692,6 +692,10 @@ def Annotation(name):
 class BaseKey(object):
     """Base type for binding keys."""
 
+    def __init__(self):
+        raise Exception('Instantiation of %s prohibited - it is derived from BaseKey '
+                        'so most likely you should bind it to something.' % (self.__class__,))
+
 
 def Key(name):
     """Create a new type key.

--- a/injector_test.py
+++ b/injector_test.py
@@ -35,6 +35,10 @@ def prepare_basic_injection():
 
     return A, B
 
+def test_key_cannot_be_instantiated():
+    with pytest.raises(Exception):
+        Interface = Key('Interface')
+        i = Interface()
 
 def test_get_default_injected_instances():
     A, B = prepare_basic_injection()


### PR DESCRIPTION
Basically every time I end up with instance of type generated using `Key` is because I've forgotten to bind interface to implementation, this patch helps make it clear as soon as possible that something's wrong.
