### PR TITLE
Make AssistedBuilder injection safe to use with multiple injectors

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -271,8 +271,8 @@ class Binder(object):
         elif issubclass(type(to), type):
             return ClassProvider(to, self.injector)
         elif isinstance(interface, AssistedBuilder):
-            self.injector.install_into(interface)
-            return InstanceProvider(interface)
+            builder = AssistedBuilderImplementation(interface.interface, self.injector)
+            return InstanceProvider(builder)
         elif isinstance(to, interface):
             return InstanceProvider(to)
         elif issubclass(type(interface), type):
@@ -731,9 +731,14 @@ class AssistedBuilder(object):
     def __init__(self, interface):
         self.interface = interface
 
+class AssistedBuilderImplementation(object):
+    def __init__(self, interface, injector):
+        self.interface = interface
+        self.injector = injector
+
     def build(self, **kwargs):
         key = BindingKey(self.interface, None)
-        binder = self.__injector__.binder
+        binder = self.injector.binder
         binding = binder.get_binding(None, key)
         provider = binding.provider
         try:
@@ -741,7 +746,7 @@ class AssistedBuilder(object):
         except AttributeError:
             raise Error('Assisted building works only with ClassProviders, '
                         'got %r for %r' % (provider, self.interface))
-        return self.__injector__.create_object(cls, additional_kwargs=kwargs)
+        return self.injector.create_object(cls, additional_kwargs=kwargs)
 
 def _describe(c):
     if hasattr(c, '__name__'):

--- a/injector_test.py
+++ b/injector_test.py
@@ -679,6 +679,17 @@ def test_assisted_builder_uses_bindings():
     x = builder.build(b=333)
     assert ((type(x), x.b) == (NeedsAssistance, 333))
 
+def test_assisted_builder_injection_is_safe_to_use_with_multiple_injectors():
+    class X(object):
+        @inject(builder=AssistedBuilder(NeedsAssistance))
+        def y(self, builder):
+            return builder
+
+    i1, i2 = Injector(), Injector()
+    b1 = i1.get(X).y()
+    b2 = i2.get(X).y()
+    assert ((b1.injector, b2.injector) == (i1, i2))
+
 class TestThreadSafety(object):
     def setup(self):
         def configure(binder):


### PR DESCRIPTION
`AssistedBuilder` implementation caused all builders injected into particular method by `@inject(x=AssistedBuilder(y))` decoration to share reference to last injector that was used for the injection. This behaviour is not optimal :)
