### PR TITLE
Fix TypeError caused by use_annotations=True on Python 3.3

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -664,7 +664,11 @@ class Injector(object):
         additional_kwargs = additional_kwargs or {}
         log.debug('%sCreating %r object with %r', self._log_prefix, cls, additional_kwargs)
 
-        if self.use_annotations and hasattr(cls, '__init__') and not hasattr(cls.__init__, '__binding__'):
+        # (cls.__init__ is not object.__init__) is a workaround for Python 3.3
+        # where object.__init__ is a slot wrapper that can't be inspected
+        if self.use_annotations and hasattr(cls, '__init__') and \
+           not hasattr(cls.__init__, '__binding__') and \
+           cls.__init__ is not object.__init__:
             bindings = self._infer_injected_bindings(cls.__init__)
             cls.__init__ = inject(**bindings)(cls.__init__)
 


### PR DESCRIPTION
I've encountered following error when trying to create Injector with use_annotations=True on python 3.3

```
Traceback (most recent call last):
  File "/home/iley/work/cms/abt/testing.py", line 66, in setUp
    super(AbtTestMixin, self).setUp()
  File "/home/iley/work/cms/frogstar/testing/fixture.py", line 10, in setUp
    self.injector = Injector(self.modules, use_annotations=True)
  File "/home/iley/.virtualenvs/cms3k/lib/python3.3/site-packages/injector.py", line 549, in __init__
    self.binder.install(module)
  File "/home/iley/.virtualenvs/cms3k/lib/python3.3/site-packages/injector.py", line 305, in install
    instance = self.injector.create_object(module)
  File "/home/iley/.virtualenvs/cms3k/lib/python3.3/site-packages/injector.py", line 591, in create_object
    bindings = self._infer_injected_bindings(cls.__init__)
  File "/home/iley/.virtualenvs/cms3k/lib/python3.3/site-packages/injector.py", line 618, in _infer_injected_bindings
    spec = getfullargspec(callable)
  File "/usr/lib/python3.3/inspect.py", line 851, in getfullargspec
    raise TypeError('{!r} is not a Python function'.format(func))
TypeError: <slot wrapper '__init__' of 'object' objects> is not a Python function
```

Turns out in Python 3.3 `object.__init__` is some kind of built-in object and it cannot be inspected via `inspect.getfullargspec()`. So I added a workaround for such case.
