### PR TITLE
Fix python block code format specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Injector works with CPython 2.6+/3.2+ and PyPy 1.9+.
 
 Example:
 
-```python
+```pycon
 >>> from injector import Injector, inject, Key
 >>> GreetingType = Key('GreetingType')
 >>>


### PR DESCRIPTION
Use `pycon` instead `python`.  Otherwise "Hello, John!" string highlighted with error.
