### PR TITLE
Always call CallableProvider._callable with injection

### DIFF
--- a/injector_test.py
+++ b/injector_test.py
@@ -1075,3 +1075,20 @@ def test_deprecated_module_configure_injection():
         warnings.simplefilter("always")
         Injector([Test(), configure])
         assert len(w) == 2
+
+
+def test_callable_provider_injection():
+    Name = Key("Name")
+    Message = Key("Message")
+
+    @inject(name=Name)
+    def create_message(name):
+        return "Hello, " + name
+
+    def configure(binder):
+        binder.bind(Name, to="John")
+        binder.bind(Message, to=create_message)
+
+    injector = Injector([configure])
+    msg = injector.get(Message)
+    assert msg == "Hello, John"


### PR DESCRIPTION
It's sometimes useful to inject some value into a callable which provides another value. So I've changed the CallableProvider similarly to how ClassProvider works. I've also added a unit test. Unfortunately I've had to remove a doctest because I have not found any easy way to make it correct after my changes.
