### PR TITLE
rename setup -> setup_method

### DIFF
--- a/injector_test.py
+++ b/injector_test.py
@@ -953,7 +953,7 @@ def test_assisted_builder_injection_is_safe_to_use_with_child_injectors():
 
 
 class TestThreadSafety:
-    def setup(self):
+    def setup_method(self):
         self.event = threading.Event()
 
         def configure(binder):


### PR DESCRIPTION
Removes deprecated `setup` method on `TestThreadSafety`. See [here](https://docs.pytest.org/en/stable/deprecations.html#setup-teardown) for info.