### PR TITLE
Make Mypy happy

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -859,7 +859,7 @@ class Module:
                             % (function.__name__, type(self), e)
                         ) from e
                     return_type = annotations['return']
-                    binding = function.__func__.__binding__ = Binding(
+                    binding = cast(Any, function.__func__).__binding__ = Binding(
                         interface=return_type, provider=binding.provider, scope=binding.scope
                     )
                 bind_method = binder.multibind if binding.is_multibinding() else binder.bind


### PR DESCRIPTION
We're assigning to an attribute Mypy doesn't know about. The error it raised:

    injector/__init__.py:862: error: "FunctionType" has no attribute "__binding__"  [attr-defined]
    Found 1 error in 1 file (checked 1 source file)