### PR TITLE
Remove one dev dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-cov>=2.5.1
-dataclasses;python_version<"3.7"
 mypy;implementation_name=="cpython"
 black;implementation_name=="cpython"
 check-manifest


### PR DESCRIPTION
Not used, we don't support Python 3.6 anymore.