### PR TITLE
Drop official Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9", "pypy3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The core values of Injector are:
 * Documentation: https://injector.readthedocs.org
 * Change log: https://injector.readthedocs.io/en/latest/changelog.html
 
-Injector works with CPython 3.7+ and PyPy 3 implementing Python 3.7+.
+Injector works with CPython 3.8+ and PyPy 3 implementing Python 3.8+.
 
 A Quick Example
 ---------------


### PR DESCRIPTION
It's really old now and it reached its end of life stage.

Supporting the last four minor versions (3.8-3.11) should be good enough.