### PR TITLE
Remove some no longer necessary code

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -1119,10 +1119,6 @@ def get_bindings(callable: Callable) -> Dict[str, type]:
         >>> get_bindings(function3)
         {'a': <class 'int'>}
 
-        >>> import sys, pytest
-        >>> if sys.version_info < (3, 7, 0):
-        ...     pytest.skip('Python 3.7.0 required for sufficient Annotated support')
-
         >>> # The simple case of no @inject but injection requested with Inject[...]
         >>> def function4(a: Inject[int], b: str) -> None:
         ...     pass

--- a/injector_test.py
+++ b/injector_test.py
@@ -1544,21 +1544,13 @@ def test_newtype_integration_works():
     assert injector.get(UserID) == 123
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="Requires Python 3.6+")
 def test_dataclass_integration_works():
     import dataclasses
 
-    # Python 3.6+-only syntax below
-    exec(
-        """
-@inject
-@dataclasses.dataclass
-class Data:
-    name: str
-    """,
-        locals(),
-        globals(),
-    )
+    @inject
+    @dataclasses.dataclass
+    class Data:
+        name: str
 
     def configure(binder):
         binder.bind(str, to='data')


### PR DESCRIPTION
We no longer support Python versions old enough to warrant these workarounds.