### PR TITLE
Provide ReadTheDocs configuration (#275)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# TODO: pin the development dependency versions
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,8 @@ build:
 
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
+  # TODO: Enable this when we get rid of the existing warnings
+  # fail_on_warning: true
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,10 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
+python:
+  install:
+    - method: pip
+      path: .
 # TODO: pin the development dependency versions
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
 #     - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,4 @@ recursive-include docs *.html
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile
-
-ignore .readthedocs.yaml
+exclude .readthedocs.yaml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,5 @@ recursive-include docs *.html
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile
+
+ignore .readthedocs.yaml


### PR DESCRIPTION
RTD has been requiring a configuration file for a while, this change should resolve the currently ongoing documentation build failures.