### PR TITLE
Reduce repetitive CI builds when pushing to the main repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
I like to push branches to the upstream repository and create PRs from that.

With the previous configuration all jobs were triggered twice – once for the push event, once for the pull_request event.

That was wasting resources and creating noise in the PRs.