### PR TITLE
Enable Python 3.12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "pypy3.8", "pypy3.9", "pypy3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
It's been out for a while. The change is needed to make sure we don't become unwillingly incompatible.