### PR TITLE
Invalid bind_scope

### DIFF
--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -49,11 +49,11 @@ This can be used like so::
     class MyClass:
         pass
 
-Scopes are bound in modules with the :meth:`Binder.bind_scope` method::
+Scopes are bound in modules with the :meth:`Binder.install` method::
 
     class MyModule(Module):
         def configure(self, binder):
-            binder.bind_scope(CustomScope)
+            binder.install(CustomScope)
 
 Scopes can be retrieved from the injector, as with any other instance. They are singletons across the life of the injector::
 


### PR DESCRIPTION
Replacing `bind_scope` with `install` as `bind_scope` does not exist.