### PR TITLE
Fix for annotated injection with attribute. Replacing with origins on…

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -1238,9 +1238,10 @@ def _infer_injected_bindings(callable: Callable, only_explicit_bindings: bool) -
         bindings.pop(spec.varkw, None)
 
     for k, v in list(bindings.items()):
-        if _is_specialization(v, Annotated):
-            v, metadata = v.__origin__, v.__metadata__
-            bindings[k] = v
+        if _is_specialization(v, Annotated) :
+            origin, metadata = v.__origin__, v.__metadata__
+            if _inject_marker in metadata or _noinject_marker in metadata:  #replace original annotated type with its origin if annotation is injection marker
+                bindings[k] = origin
         else:
             metadata = tuple()
 

--- a/injector_test.py
+++ b/injector_test.py
@@ -1754,3 +1754,16 @@ def test_annotated_non_comparable_types():
     injector = Injector([configure])
     assert injector.get(foo) == 123
     assert injector.get(bar) == 456
+
+
+def test_annotated_injection_with_attribute():
+
+    foo = Annotated[str, "foo"]
+    bar = Annotated[str, "bar"]
+
+    # noinspection PyUnusedLocal
+    @inject
+    def target(val_foo: foo, val_bar: bar):
+        pass
+
+    assert get_bindings(target) == {'val_foo': foo, 'val_bar': bar}


### PR DESCRIPTION
There is a problem injecting annotated type. I created a test for that to demonstrate. Shortly: we should not replace annotated type with its origin while building bindings if the annotation is not a injection marker (ie inject or noinject)