### PR TITLE
Support optional parameters

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -1253,9 +1253,8 @@ def _infer_injected_bindings(callable: Callable, only_explicit_bindings: bool) -
         if only_explicit_bindings and _inject_marker not in metadata or _noinject_marker in metadata:
             del bindings[k]
         elif _is_specialization(v, Union) or _is_new_union_type(v):
-            # We don't treat Optional parameters in any special way at the moment.
             union_members = v.__args__
-            new_members = tuple(set(union_members) - {type(None)})
+            new_members = tuple(set(union_members))
             # mypy stared complaining about this line for some reason:
             #     error: Variable "new_members" is not valid as a type
             new_union = Union[new_members]  # type: ignore

--- a/injector_test.py
+++ b/injector_test.py
@@ -1674,6 +1674,15 @@ def test_get_bindings():
     assert get_bindings(function11) == {'a': int}
 
 
+    # This will not inject `None` even if there is a provider configured to provide
+    # str | None elsewhere in the graph because `None` is stripped in
+    @inject
+    def function12(a: str | None):
+        pass
+
+    assert get_bindings(function12) == {'a': str | None}
+
+
 # Tests https://github.com/alecthomas/injector/issues/202
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10+")
 def test_get_bindings_for_pep_604():

--- a/injector_test.py
+++ b/injector_test.py
@@ -1674,8 +1674,7 @@ def test_get_bindings():
     assert get_bindings(function11) == {'a': int}
 
 
-    # This will not inject `None` even if there is a provider configured to provide
-    # str | None elsewhere in the graph because `None` is stripped in
+    # This should correctly resolve str | None
     @inject
     def function12(a: str | None):
         pass
@@ -1690,7 +1689,7 @@ def test_get_bindings_for_pep_604():
     def function1(a: int | None) -> None:
         pass
 
-    assert get_bindings(function1) == {'a': int}
+    assert get_bindings(function1) == {'a': Union[int, None]}
 
     @inject
     def function1(a: int | str) -> None:


### PR DESCRIPTION
## Overview
Support bindings for optional parameters.

## Background
In application code some pieces of configuration can be considered optional. For example, consider an API server that supports authentication/authorization in staging and production, but can have this feature "turned off" for development by simply omitting the `auth` section of the server configuration.

`injector` already supports providers for optional types e.g.:

```python
AuthConfig: TypeAlias = OAuth2Config | OidcConfig


@dataclass
class AppConfig:
    auth: AuthConfig | None = None


class ConfigurationModule(Module):
    @singleton
    @provider
    def provide_app_config(self) -> AppConfig:
        return AppConfig.load()

    @singleton
    @provider
    def provide_auth_config_or_none(self, app_config: AppConfig) -> AuthConfig | None:
        return app_config.auth
```


In this example, I can easily set up an injector and get `AuthConfig | None` from the graph:

```python
World: Final[Injector] = Injector(ConfigurationModule())

if __name__ == "__main__":
    appconfig = World.get(AppConfig)
    print(f"AppConfig resolved: {appconfig!s}"
    
    authconfig = World.get(AuthConfig | None)
    print(f"AuthConfig | None resolved: {authconfig!s}")
``` 

When this is run it prints:

```text
AppConfig resolved: ...   # real values hidden for brevity and security
AuthConfig | None resolved: None
```

However, if I then write a provider function which requests `AuthConfig | None` as a dependency like:

```python
class MiddlewareModule(Module):
    @provider
    @singleton
    def provide_authn_middleware(
        self, config: AuthConfig | None, injector: Injector
    ) -> AuthenticationMiddleware[Secret[str] | None]:
        middleware: AuthenticationMiddleware[Secret[str] | None]
        match config:
            case OAuth2Config() | OidcConfig():
                middleware = injector.get(BearerTokenMiddleware)
            case None:
                middleware = NoopAuthenticationMiddleware()
            case _:
                assert_never(config)
        return middleware
```

The injector raises indicating there is no provider for `Union[OAuth2Config, OidcConfig]` (type names shortened for brevity). Given the `AuthConfig: TypeAlias = OAuth2Config | OidcConfig` alias from earlier this message implies something somewhere is requesting plain `AuthConfig` as a dependency rather than `AuthConfig | None`, which has a provider in the graph.

After a lot of debugging, I found that the function `_infer_injected_bindings` [removes `NoneType` from unions](https://github.com/python-injector/injector/blob/13cf0d9b086cb50c56c0ae073a79159530908228/injector/__init__.py#L1256-L1258) before resolving the rest of the injectable dependencies from a function signature:

```python
# We don't treat Optional parameters in any special way at the moment.
union_members = v.__args__
new_members = tuple(set(union_members) - {type(None)})
```

After removing the set difference operation from the assignment to `new_members` the code examples I share above start working instead of raising an exception about missing providers.

## Solution

The solution proposed here removes `- {type(None)}` from `new_members = ...` to allow optional dependencies to be fulfilled if there is a provider configured for them.

I also included a test to demonstrate the behavior in `test_get_bindings`. In the first commit the new test fails, but in the second commit with the proposed change applied it passes. 

This patch induces a change in the test for `test_get_bindings_for_pep_604` since now `a: int | None` resolves to `int | None` instead of just `int`. 

The rest of the test suite passes with this patch in place, so from what I can tell there aren't any unintended side effects on the rest of the codebase, but let me know if I'm missing something. Looking forward to getting your thoughts on this!